### PR TITLE
Add MontePy as a tracked repo. 

### DIFF
--- a/.github/workflows/repostats-for-idaholab.yml
+++ b/.github/workflows/repostats-for-idaholab.yml
@@ -59,6 +59,7 @@ jobs:
           - idaholab/malamute
           - idaholab/Malcolm
           - idaholab/mastodon
+          - idaholab/MontePy
           - idaholab/moose
           - idaholab/moose-language-support
           - idaholab/moosetools


### PR DESCRIPTION
[MontePy](https://github.com/idaholab/MontePy/) is a new addition to the INL Open Source family, and it would be nice to track its statistics as well. 